### PR TITLE
Use non-recursive mappings

### DIFF
--- a/plugin/iterm-test-runner.vim
+++ b/plugin/iterm-test-runner.vim
@@ -21,5 +21,5 @@ endfunction
 command! -nargs=* TTRF call s:ITermTestRunnerFile()
 command! -nargs=* TTRL call s:ITermTestRunnerLine()
 
-nmap <leader>t :call <SID>ITermTestRunnerLine()<cr>
-nmap <leader>T :call <SID>ITermTestRunnerFile()<cr>
+nnoremap <leader>t :call <SID>ITermTestRunnerLine()<cr>
+nnoremap <leader>T :call <SID>ITermTestRunnerFile()<cr>


### PR DESCRIPTION
All Vim mappings should be non-recursive. Although unlikely, if your second argument is ever mapped to something else in a different place, `nnoremap` will prevent a recursive call and just execute the second argument as written.

Source:

http://learnvimscriptthehardway.stevelosh.com/chapters/05.html#nonrecursive-mapping